### PR TITLE
Migrate to async await and futures-0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,13 @@ repository = "https://github.com/oefd/tokio-socketcan"
 
 [dependencies]
 socketcan = "1.7"
-futures = "0.1"
-tokio = "0.1"
+futures = "0.3"
+tokio-net = "0.2.0-alpha.6"
 mio = "0.6"
 libc = "0.2"
+
+[dev-dependencies]
+futures-timer = "2.0"
+futures-util = "0.3"
+tokio = "0.2.0-alpha.6"
+tokio-test = "0.2.0-alpha.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ thiserror = "1.0"
 tokio = { version = "0.2", features = ["net", "macros"] }
 
 [dev-dependencies]
-futures-timer = "2.0"
+futures-timer = "3.0"
 futures-util = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,11 @@ repository = "https://github.com/oefd/tokio-socketcan"
 [dependencies]
 socketcan = "1.7"
 futures = "0.3"
-tokio-net = "0.2.0-alpha.6"
 mio = "0.6"
 libc = "0.2"
+thiserror = "1.0"
+tokio = { version = "0.2", features = ["net", "macros"] }
 
 [dev-dependencies]
 futures-timer = "2.0"
 futures-util = "0.3"
-tokio = "0.2.0-alpha.6"
-tokio-test = "0.2.0-alpha.6"

--- a/README.md
+++ b/README.md
@@ -7,15 +7,18 @@
 # Example  echo server
 
 ```rust
-use futures::stream::Stream;
-use futures::future::{self, Future};
+use futures_util::stream::StreamExt;
+use tokio_socketcan::{CANSocket, Error};
 
-let socket_rx = tokio_socketcan::CANSocket::open("vcan0").unwrap();
-let socket_tx = tokio_socketcan::CANSocket::open("vcan0").unwrap();
-
-tokio::run(socket_rx.for_each(move |frame| {
-    socket_tx.write_frame(frame)
-}).map_err(|_err| {}));
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let mut socket_rx = CANSocket::open("vcan0")?;
+    let socket_tx = CANSocket::open("vcan0")?;
+    while let Some(Ok(frame)) = socket_rx.next().await {
+        socket_tx.write_frame(frame)?.await?;
+    }
+    Ok(())
+}
 ```
 
 # Testing

--- a/examples/print_frames.rs
+++ b/examples/print_frames.rs
@@ -1,0 +1,16 @@
+use tokio_socketcan::CANSocket;
+use futures_util::StreamExt;
+use tokio;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut socket_rx = CANSocket::open("vcan0").unwrap();
+
+    println!("Reading on vcan0");
+
+    while let Some(next) = socket_rx.next().await {
+        println!("{:#?}", next);
+    }
+
+    Ok(())
+}

--- a/examples/print_frames.rs
+++ b/examples/print_frames.rs
@@ -1,6 +1,6 @@
-use tokio_socketcan::CANSocket;
 use futures_util::StreamExt;
 use tokio;
+use tokio_socketcan::CANSocket;
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {

--- a/examples/send_frames.rs
+++ b/examples/send_frames.rs
@@ -1,16 +1,16 @@
 use futures_timer::Delay;
 use std::time::Duration;
 use tokio;
-use tokio_socketcan::{CANFrame, CANSocket};
+use tokio_socketcan::{CANFrame, CANSocket, Error};
 
 #[tokio::main]
-async fn main() -> std::io::Result<()> {
+async fn main() -> Result<(), Error> {
     let socket_tx = CANSocket::open("vcan0").unwrap();
 
     loop {
         let frame = CANFrame::new(0x1, &[0], false, false).unwrap();
         println!("Writing on vcan0");
-        socket_tx.write_frame(frame).await?;
+        socket_tx.write_frame(frame)?.await?;
         println!("Waiting 3 seconds");
         Delay::new(Duration::from_secs(3)).await;
     }

--- a/examples/send_frames.rs
+++ b/examples/send_frames.rs
@@ -1,0 +1,17 @@
+use futures_timer::Delay;
+use std::time::Duration;
+use tokio;
+use tokio_socketcan::{CANFrame, CANSocket};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let socket_tx = CANSocket::open("vcan0").unwrap();
+
+    loop {
+        let frame = CANFrame::new(0x1, &[0], false, false).unwrap();
+        println!("Writing on vcan0");
+        socket_tx.write_frame(frame).await?;
+        println!("Waiting 3 seconds");
+        Delay::new(Duration::from_secs(3)).await;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,7 @@ impl CANSocket {
     pub fn write_frame(&self, frame: CANFrame) -> CANWriteFuture {
         CANWriteFuture {
             socket: self.clone(),
-            frame: frame,
+            frame,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! #[tokio::main]
 //! async fn main() -> Result<(), Error> {
 //!     let mut socket_rx = CANSocket::open("vcan0")?;
-//!     let mut socket_tx = CANSocket::open("vcan0")?;
+//!     let socket_tx = CANSocket::open("vcan0")?;
 //!
 //!     while let Some(Ok(frame)) = socket_rx.next().await {
 //!         socket_tx.write_frame(frame)?.await;


### PR DESCRIPTION
Ok I also migrated the tests and docs. There is currently still one false positive in the test. Nevertheless I thought it's worth sharing. What I kind of still dislike but have no idea how to work around is that this will currently only work with tokio. Given that the crate is called tokio-socketcan I assume that's fine, but I think it would be great if we could figure out how to make this executor agnostic so it also forks with e.g. the [futures-executor](https://docs.rs/futures-executor/0.3.1/futures_executor/) and [async-std](https://github.com/async-rs/async-std).