### PR TITLE
Update to tokio 1.1 and mio 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,16 @@ repository = "https://github.com/oefd/tokio-socketcan"
 [dependencies]
 socketcan = "1.7"
 futures = "0.3"
-mio = "0.6"
+mio = "0.7"
 libc = "0.2"
 thiserror = "1.0"
-tokio = { version = "0.2", features = ["net", "macros"] }
+tokio = { version = "1.1", features = ["net"] }
 
 [dev-dependencies]
 futures-timer = "3.0"
 futures-util = "0.3"
+
+[dev-dependencies.tokio]
+version = "*"
+# required for tokio::test
+features = ["macros", "rt-multi-thread"]


### PR DESCRIPTION
```
cargo run --example print_frames
```
seems to indicate that only one frame is received, so there is still something not working