### PR TITLE
Add support for CAN FD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ license = "MIT"
 repository = "https://github.com/oefd/tokio-socketcan"
 
 [dependencies]
-socketcan = "1.7"
+# socketcan = "1.7"
+socketcan = { git = "https://github.com/j4r0u53k/socketcan-rs.git", branch = "can-fd" }
 futures = "0.3"
 mio = "0.6"
 libc = "0.2"
@@ -18,3 +19,6 @@ tokio = { version = "0.2", features = ["net", "macros"] }
 [dev-dependencies]
 futures-timer = "3.0"
 futures-util = "0.3"
+
+[features]
+can_fd = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,11 @@ impl CANSocket {
         Ok(CANSocket(PollEvented::new(EventedCANSocket(sock))?))
     }
 
+    #[cfg(feature = "can_fd")]
+    pub fn set_fd_frames(&self, enable: bool) -> io::Result<()> {
+        self.0.get_ref().0.set_fd_frames(enable)
+    }
+
     /// Sets the filter mask on the socket
     pub fn set_filter(&self, filters: &[socketcan::CANFilter]) -> io::Result<()> {
         self.0.get_ref().0.set_filter(filters)


### PR DESCRIPTION
**NOTE:**
After the `can-fd` branch in `socketcan-rs` repo (https://github.com/j4r0u53k/socketcan-rs) is merged, one should edit Cargo.toml in this project appropriately to point to the upstream.